### PR TITLE
upgrade cssnext from 0.4.0 to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "flex.css"
   ],
   "devDependencies": {
-    "cssnext": "^0.4.0"
+    "cssnext": "^1.6.0"
   },
   "scripts": {
     "setup": "npm install && mkdir -p build",


### PR DESCRIPTION
- Upgraded cssnext to latest - beyond support for imports without reference to node_modules path. 
- [cssnext 0.6.0 Changelog](https://github.com/cssnext/cssnext/blob/master/CHANGELOG.md#060---2014-11-24)
